### PR TITLE
Add helpers to the GoPKG

### DIFF
--- a/platform/database/database.go
+++ b/platform/database/database.go
@@ -3,6 +3,7 @@ package database
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
@@ -58,4 +59,8 @@ func IsUniqueConstraintError(err error, constraintName string) bool {
 	}
 
 	return e.Code == "23505" && e.Constraint == constraintName
+}
+
+func GetCurrentTimestamp() time.Time {
+	return time.Now().UTC().Truncate(time.Millisecond)
 }

--- a/platform/tests/tests.go
+++ b/platform/tests/tests.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func AssertString(testProvider *testing.T, expected string, received string, errorMessage string) {
+	if expected != received {
+		message := fmt.Sprintf("\t%s. \nExpected: %v, \nhave:  %v", errorMessage, expected, received)
+		testProvider.Fatalf(message, expected, received)
+	}
+}
+
+func AssertTimestamp(testProvider *testing.T, expected time.Time, received time.Time, errorMessage string) {
+	if !expected.Equal(received) {
+		message := fmt.Sprintf("\t%s. \nExpected: %v, \nhave:  %v", errorMessage, expected, received)
+		testProvider.Fatalf(message, expected, received)
+	}
+}
+
+func AssertBoolean(testProvider *testing.T, expected bool, received bool, errorMessage string) {
+	if expected != received {
+		message := fmt.Sprintf("\t%s. \nExpected: %v, \nhave:  %v", errorMessage, expected, received)
+		testProvider.Fatalf(message, expected, received)
+	}
+}


### PR DESCRIPTION
In this PR I add some functions which I think can be shared across our services. 

One is a function to generate a timestamp to insert in the database with a time zone and truncated. This is because Go creates a timestamp with nanoseconds while our DB only supports timestamps until milliseconds . This will ensure consistent timestamps across our services.

The other one are some assert functions which can help whilst writing tests.