### PR TITLE
Add the functionality to create sub routers

### DIFF
--- a/platform/web/router.go
+++ b/platform/web/router.go
@@ -89,6 +89,18 @@ func (a *Router) defineHandler(handler Handler, middlewares ...Middleware) http.
 	}
 }
 
+func (a *Router) NewSubRouter(pathPrefix string, middleWares ...Middleware) *Router {
+	subRouter := *a
+
+	subRouter.Router = a.PathPrefix(pathPrefix).Subrouter()
+
+	for _, m := range middleWares {
+		subRouter.middlewares = append(subRouter.middlewares, m)
+	}
+
+	return &subRouter
+}
+
 func (a *Router) SignalShutdown() {
 	a.shutdown <- syscall.SIGTERM
 }


### PR DESCRIPTION
In this PR I created a method on our custom router which allows us to create sub routers. This will allow us to add middleware to a certain group of routes.

With this implementation you can add a sub router like this:
```
usersSubRouter := router.NewSubRouter("/users", someMiddleware(...params))
usersSubrouter.HandleFunc(...)
``` 

It offers the same functionality as adding routes to a normal router without exposing the underlying package we use for routing in our apps.