### PR TITLE
Reset log position

### DIFF
--- a/platform/web/response.go
+++ b/platform/web/response.go
@@ -28,10 +28,11 @@ func RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
 	webErr, ok := errors.Unwrap(err).(*Error)
 	if !ok {
 		v := ctx.Value(KeyValues).(*Values)
-		err = NewErrUnmanagedResponse(v.TraceID)
-		webErr = err.(*Error)
 
 		monitoring.CaptureException(err).Log()
+
+		err = NewErrUnmanagedResponse(v.TraceID)
+		webErr = err.(*Error)
 	}
 
 	return Respond(ctx, w, webErr, webErr.HTTPCode)


### PR DESCRIPTION
This PR makes sure we get to see the original unhandled error, not the one we create from our own package. This is an error which slipped in while reformatting code manually.