### PR TITLE
add ping and healthz

### DIFF
--- a/platform/web/server.go
+++ b/platform/web/server.go
@@ -1,7 +1,9 @@
 package web
 
 import (
+	"context"
 	_ "expvar" // Register the expvar handlers
+	"log"
 	"net/http"
 	_ "net/http/pprof" // Register the pprof handlers
 	"time"
@@ -39,6 +41,15 @@ func NewServer(config ServerConfig, router http.Handler) *http.Server {
 	return &server
 }
 
-func NewMonitoringServer(config ServerConfig) *http.Server {
-	return NewServer(config, http.DefaultServeMux)
+func NewMonitoringServer(config ServerConfig, logger *log.Logger, healthzHandler Handler) *http.Server {
+	router := NewRouter(logger, DefaultMiddlewares(logger))
+
+	router.HandleFunc("GET", "/ping", handlePing)
+	router.HandleFunc("GET", "/healthz", healthzHandler)
+	return NewServer(config, router)
+}
+
+func handlePing(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) error {
+	w.WriteHeader(http.StatusOK)
+	return nil
 }

--- a/platform/web/server.go
+++ b/platform/web/server.go
@@ -44,12 +44,12 @@ func NewServer(config ServerConfig, router http.Handler) *http.Server {
 func NewMonitoringServer(config ServerConfig, logger *log.Logger, healthzHandler Handler) *http.Server {
 	router := NewRouter(logger, DefaultMiddlewares(logger))
 
-	router.HandleFunc("GET", "/ping", handlePing)
+	router.HandleFunc("GET", "/ping", pingHandler)
 	router.HandleFunc("GET", "/healthz", healthzHandler)
 	return NewServer(config, router)
 }
 
-func handlePing(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) error {
+func pingHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) error {
 	w.WriteHeader(http.StatusOK)
 	return nil
 }


### PR DESCRIPTION
## Details 

This pull request add ping and health endpoints to the monitoring server which come with `go-pkg`.

- ping is added on `GET /ping` it's a simple handler that is not configurable 
- healthz is added on `GET /healthz`, the handler should be provided by the implementor and be passed either to `Application.Start` or `Application.StartServers` 

Not sure to be really happy with this implementation but I hadn't really other ideas so feel free to make suggestions. 