### PR TITLE
higher level implementation of healthz checker

### DIFF
--- a/platform/web/healthz_handler.go
+++ b/platform/web/healthz_handler.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"context"
+	"net/http"
+)
+
+type HealthzState string
+
+const (
+	HealthzStateHealthy   HealthzState = "healthy"
+	HealthzStateDegraded  HealthzState = "degraded"
+	HealthzStateUnhealthy HealthzState = "unhealthy"
+)
+
+type HealthzChecker func() HealthzStatus
+
+type HealthzStatus struct {
+	Type        string            `json:"type"`
+	Description string            `json:"description"`
+	Error       string            `json:"error,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	State       HealthzState      `json:"state"`
+}
+
+type HealthzResponse struct {
+	State    string          `json:"state"`
+	Services []HealthzStatus `json:"services"`
+}
+
+func HealthzHandler(serviceCheckers []HealthzChecker) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) error {
+		var response HealthzResponse
+
+		state := HealthzStateHealthy
+
+		for _, serviceChecker := range serviceCheckers {
+			service := serviceChecker()
+			if state != HealthzStateUnhealthy {
+				switch service.State {
+				case HealthzStateUnhealthy:
+					state = HealthzStateUnhealthy
+
+				case HealthzStateDegraded:
+					state = HealthzStateDegraded
+				}
+			}
+
+			response.Services = append(response.Services, service)
+		}
+
+		response.State = string(state)
+
+		Respond(ctx, w, response, state.httpStatus())
+		return nil
+	}
+}
+
+func (state HealthzState) httpStatus() int {
+	if state == HealthzStateUnhealthy {
+		return http.StatusServiceUnavailable
+	}
+
+	return http.StatusOK
+}

--- a/platform/web/server.go
+++ b/platform/web/server.go
@@ -41,11 +41,11 @@ func NewServer(config ServerConfig, router http.Handler) *http.Server {
 	return &server
 }
 
-func NewMonitoringServer(config ServerConfig, logger *log.Logger, healthzHandler Handler) *http.Server {
+func NewMonitoringServer(config ServerConfig, logger *log.Logger, serviceCheckers []HealthzChecker) *http.Server {
 	router := NewRouter(logger, DefaultMiddlewares(logger))
 
 	router.HandleFunc("GET", "/ping", pingHandler)
-	router.HandleFunc("GET", "/healthz", healthzHandler)
+	router.HandleFunc("GET", "/healthz", HealthzHandler(serviceCheckers))
 	return NewServer(config, router)
 }
 


### PR DESCRIPTION
## Details 

The following patch updates the healthz handler feature from expecting a handler to expecting a collection of Service Checkers.
A Service Checker is a function which request the status of a service that the current service rely on. The status can take three values: `healthy`, `degraded`, `unhealthy`, the status of the current service will take the worst value returned by its checkers. 