### PR TITLE
Divide events functions between publishing and consuming

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go v1.1.2 h1:mg/7d+BzubBPrPpH1bdeF85BQZYV85j7Ljqat3+m+qE=
 github.com/cloudevents/sdk-go v1.1.2/go.mod h1:ss+jWJ88wypiewnPEzChSBzTYXGpdcILoN9YHk8uhTQ=
-github.com/cloudevents/sdk-go/v2 v2.0.0-preview6 h1:IYRl0IoWKRZE+1f9Zlm8qtc6zKg/wq4k7TKBDbIq1rg=
-github.com/cloudevents/sdk-go/v2 v2.0.0-preview6/go.mod h1:zbpxUOAoR8b4Shvo1GyHbcL/S/hgr1WJ3rNuMUgrlh0=
 github.com/cloudevents/sdk-go/v2 v2.0.0-preview8 h1:9CdwLDStqSoPxCkpnJQT0npptb8GjYcFtdELAQpXgqU=
 github.com/cloudevents/sdk-go/v2 v2.0.0-preview8/go.mod h1:akZr/joO3DfDft2KZnI91LEs15NSKIBNPYcAMBQ1xbk=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
@@ -114,6 +112,7 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
@@ -239,6 +238,7 @@ github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.2 h1:i2Ly0B+1+rzNZHHWtD4ZwKi+OU5l+uQo1iDHZ2PmiIc=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+github.com/nats-io/nats-server/v2 v2.1.4 h1:BILRnsJ2Yb/fefiFbBWADpViGF69uh4sxe8poVDQ06g=
 github.com/nats-io/nats-server/v2 v2.1.4/go.mod h1:Jw1Z28soD/QasIA2uWjXyM9El1jly3YwyFOuR8tH1rg=
 github.com/nats-io/nats-streaming-server v0.17.0/go.mod h1:ewPBEsmp62Znl3dcRsYtlcfwudxHEdYMtYqUQSt4fE0=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
@@ -383,6 +383,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -402,6 +403,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qq
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -383,7 +383,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/platform/eventing/event.go
+++ b/platform/eventing/event.go
@@ -205,19 +205,19 @@ func MarkPublisherEventAsFailed(ctx context.Context, db *sqlx.DB, ev Event, reas
 	return ev, nil
 }
 
-// ReenqueWorkerEventsToPublish changes all event status to make them ready to be picked-up again
-func ReenqueWorkerEventsToPublish(ctx context.Context, db *sqlx.DB, workerName string) error {
+// ReenqueWorkerPublisherEvents changes all event status to make them ready to be picked-up again
+func ReenqueWorkerPublisherEvents(ctx context.Context, db *sqlx.DB, workerName string) error {
 	if _, err := db.ExecContext(ctx, "UPDATE publisher_events SET status = $1 WHERE worker = $2", EventStatusQueued, workerName); err != nil {
-		return fmt.Errorf("can't re-enqueue worker's published events: %v", err)
+		return fmt.Errorf("can't re-enqueue worker's publisher events: %v", err)
 	}
 
 	return nil
 }
 
-// ReenqueWorkerEventsToConsume changes all event status to make them ready to be picked-up again
-func ReenqueWorkerEventsToConsume(ctx context.Context, db *sqlx.DB, workerName string) error {
+// ReenqueWorkerConsumerEvents changes all event status to make them ready to be picked-up again
+func ReenqueWorkerConsumerEvents(ctx context.Context, db *sqlx.DB, workerName string) error {
 	if _, err := db.ExecContext(ctx, "UPDATE consumer_events SET status = $1 WHERE worker = $2", EventStatusQueued, workerName); err != nil {
-		return fmt.Errorf("can't re-enqueue worker's published events: %v", err)
+		return fmt.Errorf("can't re-enqueue worker's consumer events: %v", err)
 	}
 
 	return nil

--- a/platform/eventing/event.go
+++ b/platform/eventing/event.go
@@ -43,12 +43,12 @@ type Event struct {
 	Error        *string        `db:"error"`
 }
 
-// CreateEvent defines a new event:
+// CreateEventToPublish creates a new events that we'll store inside the published_events table.
 // subject: the resource bound to the event (e.g current user id, etc...)
 // eventtype: is the name of the event (e.g `application.created`)
 // dataschema: is the JSON-Schema ID of the event (e.g. https://github.com/fewlinesco/myapp/jsonschema/application.created.json)
 // data: is the payload of the event itself
-func CreateEvent(ctx context.Context, tx *sqlx.Tx, subject string, eventtype string, dataschema string, data interface{}) (Event, error) {
+func CreateEventToPublish(ctx context.Context, tx *sqlx.Tx, subject string, eventtype string, dataschema string, data interface{}) (Event, error) {
 	rawdata, err := json.Marshal(data)
 	if err != nil {
 		return Event{}, fmt.Errorf("can't marshal event: %w", err)
@@ -65,7 +65,7 @@ func CreateEvent(ctx context.Context, tx *sqlx.Tx, subject string, eventtype str
 	}
 
 	_, err = tx.NamedExecContext(ctx, `
-		INSERT INTO events
+		INSERT INTO published_events
 		(id, status, subject, event_type, dataschema, data, dispatched_at)
 		VALUES
 		(:id, :status, :subject, :event_type, :dataschema, :data, :dispatched_at)
@@ -78,13 +78,48 @@ func CreateEvent(ctx context.Context, tx *sqlx.Tx, subject string, eventtype str
 	return ev, nil
 }
 
-// ScheduleNextEvents find the next events to process, mark them as "scheduled" and send them back.
+// CreateEventToConsume creates a new events that we'll store inside the consumed_events table.
+// subject: the resource bound to the event (e.g current user id, etc...)
+// eventtype: is the name of the event (e.g `application.created`)
+// dataschema: is the JSON-Schema ID of the event (e.g. https://github.com/fewlinesco/myapp/jsonschema/application.created.json)
+// data: is the payload of the event itself
+func CreateEventToConsume(ctx context.Context, tx *sqlx.Tx, subject string, eventtype string, dataschema string, data interface{}) (Event, error) {
+	rawdata, err := json.Marshal(data)
+	if err != nil {
+		return Event{}, fmt.Errorf("can't marshal event: %w", err)
+	}
+
+	ev := Event{
+		ID:           uuid.New().String(),
+		Status:       EventStatusQueued,
+		Subject:      subject,
+		DataSchema:   dataschema,
+		EventType:    eventtype,
+		Data:         types.JSONText(rawdata),
+		DispatchedAt: time.Now(),
+	}
+
+	_, err = tx.NamedExecContext(ctx, `
+		INSERT INTO consumed_events
+		(id, status, subject, event_type, dataschema, data, dispatched_at)
+		VALUES
+		(:id, :status, :subject, :event_type, :dataschema, :data, :dispatched_at)
+	`, ev)
+
+	if err != nil {
+		return ev, fmt.Errorf("can't insert: %w", err)
+	}
+
+	return ev, nil
+}
+
+// ScheduleNextEventsToConsume find the next events to consumed, mark them as "scheduled" and send them back.
 // It's done in a transaction to ensure the event is also marked as "scheduled" for other workers
-func ScheduleNextEvents(ctx context.Context, db *sqlx.DB, workerName string) ([]Event, error) {
+func ScheduleNextEventsToConsume(ctx context.Context, db *sqlx.DB, workerName string) ([]Event, error) {
 	var evs []Event
 
 	err := db.SelectContext(ctx, &evs, `
-		UPDATE events
+		UPDATE consumed_events
 		SET status = $1,
 			scheduled_at = NOW(),
 			worker = $2
@@ -110,47 +145,126 @@ func ScheduleNextEvents(ctx context.Context, db *sqlx.DB, workerName string) ([]
 	return evs, nil
 }
 
-// MarkEventAsFailed logs the failure and the timestamp. It returns the new updated event
-func MarkEventAsFailed(ctx context.Context, db *sqlx.DB, ev Event, reason string) (Event, error) {
+// ScheduleNextEventsToPublish find the next events to process, mark them as "scheduled" and send them back.
+// It's done in a transaction to ensure the event is also marked as "scheduled" for other workers
+func ScheduleNextEventsToPublish(ctx context.Context, db *sqlx.DB, workerName string) ([]Event, error) {
+	var evs []Event
+
+	err := db.SelectContext(ctx, &evs, `
+		UPDATE published_events
+		SET status = $1,
+			scheduled_at = NOW(),
+			worker = $2
+		WHERE id IN (
+			SELECT events.id
+			FROM events
+			WHERE status = 'queued'
+			ORDER BY dispatched_at ASC
+			FOR UPDATE SKIP LOCKED
+			LIMIT $3
+		)
+		RETURNING *
+	`, EventStatusScheduled, workerName, 100)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return evs, fmt.Errorf("%w: %v", ErrNoEventsToSchedule, err)
+		}
+
+		return nil, fmt.Errorf("can't select for udpdate: %v", err)
+	}
+
+	return evs, nil
+}
+
+// MarkEventToConsumeAsFailed logs the failure and the timestamp. It returns the new updated event
+func MarkEventToConsumeAsFailed(ctx context.Context, db *sqlx.DB, ev Event, reason string) (Event, error) {
 	ev.Status = EventStatusFailed
 	ev.Error = &reason
 	now := time.Now()
 	ev.FinishedAt = &now
 
-	if _, err := db.NamedExecContext(ctx, "UPDATE events SET status = :status, finished_at = :finished_at, error = :error WHERE id = :id", ev); err != nil {
+	if _, err := db.NamedExecContext(ctx, "UPDATE consumed_events SET status = :status, finished_at = :finished_at, error = :error WHERE id = :id", ev); err != nil {
 		return ev, fmt.Errorf("can't update: %v", err)
 	}
 
 	return ev, nil
 }
 
-// ReenqueWorkerEvents changes all event status to make them ready to be picked-up again
-func ReenqueWorkerEvents(ctx context.Context, db *sqlx.DB, workerName string) error {
-	if _, err := db.ExecContext(ctx, "UPDATE events SET status = 'queued' WHERE worker = $1", workerName); err != nil {
-		return fmt.Errorf("can't re-enqueue worker's events: %v", err)
+// MarkEventToPublishAsFailed logs the failure and the timestamp. It returns the new updated event
+func MarkEventToPublishAsFailed(ctx context.Context, db *sqlx.DB, ev Event, reason string) (Event, error) {
+	ev.Status = EventStatusFailed
+	ev.Error = &reason
+	now := time.Now()
+	ev.FinishedAt = &now
+
+	if _, err := db.NamedExecContext(ctx, "UPDATE published_events SET status = :status, finished_at = :finished_at, error = :error WHERE id = :id", ev); err != nil {
+		return ev, fmt.Errorf("can't update: %v", err)
+	}
+
+	return ev, nil
+}
+
+// ReenqueWorkerEventsToPublish changes all event status to make them ready to be picked-up again
+func ReenqueWorkerEventsToPublish(ctx context.Context, db *sqlx.DB, workerName string) error {
+	if _, err := db.ExecContext(ctx, "UPDATE published_events SET status = $1 WHERE worker = $2", EventStatusQueued, workerName); err != nil {
+		return fmt.Errorf("can't re-enqueue worker's published events: %v", err)
 	}
 
 	return nil
 }
 
-// ReenqueEvent changes the event status to make it ready to be picked-up again
-func ReenqueEvent(ctx context.Context, db *sqlx.DB, ev Event) error {
+// ReenqueWorkerEventsToConsume changes all event status to make them ready to be picked-up again
+func ReenqueWorkerEventsToConsume(ctx context.Context, db *sqlx.DB, workerName string) error {
+	if _, err := db.ExecContext(ctx, "UPDATE consumed_events SET status = $1 WHERE worker = $2", EventStatusQueued, workerName); err != nil {
+		return fmt.Errorf("can't re-enqueue worker's published events: %v", err)
+	}
+
+	return nil
+}
+
+// ReenqueEventToPublish changes the event status to make it ready to be picked-up again
+func ReenqueEventToPublish(ctx context.Context, db *sqlx.DB, ev Event) error {
 	ev.Status = EventStatusQueued
 
-	if _, err := db.NamedExecContext(ctx, "UPDATE events SET status = :status WHERE id = :id", ev); err != nil {
+	if _, err := db.NamedExecContext(ctx, "UPDATE published_events SET status = :status WHERE id = :id", ev); err != nil {
 		return fmt.Errorf("can't update: %v", err)
 	}
 
 	return nil
 }
 
-// MarkEventAsSent It returns the new updated event
-func MarkEventAsSent(ctx context.Context, db *sqlx.DB, ev Event) (Event, error) {
+// ReenqueEventToConsume changes the event status to make it ready to be picked-up again
+func ReenqueEventToConsume(ctx context.Context, db *sqlx.DB, ev Event) error {
+	ev.Status = EventStatusQueued
+
+	if _, err := db.NamedExecContext(ctx, "UPDATE consumed_events SET status = :status WHERE id = :id", ev); err != nil {
+		return fmt.Errorf("can't update: %v", err)
+	}
+
+	return nil
+}
+
+// MarkPublishedEventAsProcessed It returns the new updated event
+func MarkPublishedEventAsProcessed(ctx context.Context, db *sqlx.DB, ev Event) (Event, error) {
 	ev.Status = EventStatusProcessed
 	now := time.Now()
 	ev.FinishedAt = &now
 
-	if _, err := db.NamedExecContext(ctx, "UPDATE events SET status = :status, finished_at = :finished_at WHERE id = :id", ev); err != nil {
+	if _, err := db.NamedExecContext(ctx, "UPDATE published_events SET status = :status, finished_at = :finished_at WHERE id = :id", ev); err != nil {
+		return ev, fmt.Errorf("can't update: %v", err)
+	}
+
+	return ev, nil
+}
+
+// MarkConsumedEventAsProcessed It returns the new updated event
+func MarkConsumedEventAsProcessed(ctx context.Context, db *sqlx.DB, ev Event) (Event, error) {
+	ev.Status = EventStatusProcessed
+	now := time.Now()
+	ev.FinishedAt = &now
+
+	if _, err := db.NamedExecContext(ctx, "UPDATE consumed_events SET status = :status, finished_at = :finished_at WHERE id = :id", ev); err != nil {
 		return ev, fmt.Errorf("can't update: %v", err)
 	}
 

--- a/platform/eventing/sender_scheduler.go
+++ b/platform/eventing/sender_scheduler.go
@@ -102,7 +102,7 @@ func (s *SenderScheduler) Start() error {
 						cloudevent.SetType(ev.EventType)
 						cloudevent.SetDataSchema(ev.DataSchema)
 						if err := cloudevent.SetData("application/json", ev.Data); err != nil {
-							if _, err := MarkEventToPublishAsFailed(ctx, s.db, ev, err.Error()); err != nil {
+							if _, err := MarkPublisherEventAsFailed(ctx, s.db, ev, err.Error()); err != nil {
 								log(ev.ID, fmt.Sprintf("can't mark event as failed: %v", err))
 								return
 							}
@@ -111,7 +111,7 @@ func (s *SenderScheduler) Start() error {
 						if err := s.cloudEventClient.Send(ctx, cloudevent); err != nil {
 							log(ev.ID, fmt.Sprintf("re-enqueue because can't send event to the broker: %v.", err))
 
-							if err := ReenqueEventToPublish(ctx, s.db, ev); err != nil {
+							if err := ReenquePublisherEvent(ctx, s.db, ev); err != nil {
 								log(ev.ID, fmt.Sprintf("can't re-enqueue event: %v", err))
 
 								return

--- a/platform/eventing/sender_scheduler.go
+++ b/platform/eventing/sender_scheduler.go
@@ -57,7 +57,7 @@ func (s *SenderScheduler) Start() error {
 	ticker := time.NewTicker(s.PollingInterval)
 	done := make(chan error)
 
-	if err := ReenqueWorkerEvents(context.Background(), s.db, s.identifier); err != nil {
+	if err := ReenqueWorkerEventsToPublish(context.Background(), s.db, s.identifier); err != nil {
 		return err
 	}
 
@@ -78,7 +78,7 @@ func (s *SenderScheduler) Start() error {
 				ctx, cancel := context.WithTimeout(context.Background(), s.DispatchTimeout)
 				defer cancel()
 
-				evs, err := ScheduleNextEvents(ctx, s.db, s.identifier)
+				evs, err := ScheduleNextEventsToPublish(ctx, s.db, s.identifier)
 				if err != nil {
 					if errors.Is(err, ErrNoEventsToSchedule) {
 						continue
@@ -102,7 +102,7 @@ func (s *SenderScheduler) Start() error {
 						cloudevent.SetType(ev.EventType)
 						cloudevent.SetDataSchema(ev.DataSchema)
 						if err := cloudevent.SetData("application/json", ev.Data); err != nil {
-							if _, err := MarkEventAsFailed(ctx, s.db, ev, err.Error()); err != nil {
+							if _, err := MarkEventToPublishAsFailed(ctx, s.db, ev, err.Error()); err != nil {
 								log(ev.ID, fmt.Sprintf("can't mark event as failed: %v", err))
 								return
 							}
@@ -111,7 +111,7 @@ func (s *SenderScheduler) Start() error {
 						if err := s.cloudEventClient.Send(ctx, cloudevent); err != nil {
 							log(ev.ID, fmt.Sprintf("re-enqueue because can't send event to the broker: %v.", err))
 
-							if err := ReenqueEvent(ctx, s.db, ev); err != nil {
+							if err := ReenqueEventToPublish(ctx, s.db, ev); err != nil {
 								log(ev.ID, fmt.Sprintf("can't re-enqueue event: %v", err))
 
 								return
@@ -120,7 +120,7 @@ func (s *SenderScheduler) Start() error {
 							return
 						}
 
-						if _, err := MarkEventAsSent(ctx, s.db, ev); err != nil {
+						if _, err := MarkPublishedEventAsProcessed(ctx, s.db, ev); err != nil {
 							log(ev.ID, fmt.Sprintf("can't mark event as sent: %v", err))
 							return
 						}

--- a/platform/eventing/sender_scheduler.go
+++ b/platform/eventing/sender_scheduler.go
@@ -57,7 +57,7 @@ func (s *SenderScheduler) Start() error {
 	ticker := time.NewTicker(s.PollingInterval)
 	done := make(chan error)
 
-	if err := ReenqueWorkerEventsToPublish(context.Background(), s.db, s.identifier); err != nil {
+	if err := ReenqueWorkerPublisherEvents(context.Background(), s.db, s.identifier); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This pull request expose public functions that are now dedicated to events to publish or to consume. It allows us to handle the two SQL tables that we need for each kind of events.