### PR TITLE
Add a health check endpoint for the database

### DIFF
--- a/platform/application.go
+++ b/platform/application.go
@@ -112,6 +112,9 @@ func (c *ClassicalApplication) Start(arguments []string, router *web.Router, ser
 		arguments = arguments[1:]
 	}
 
+	defaultServiceCheckers := []web.HealthzChecker{database.HealthCheck(c.Database)}
+	serviceCheckers = append(defaultServiceCheckers, serviceCheckers...)
+
 	switch command {
 	case "migrate":
 		return c.StartMigrations(migrations)

--- a/platform/database/health.go
+++ b/platform/database/health.go
@@ -22,7 +22,11 @@ func HealthCheck(db *sqlx.DB) web.HealthzChecker {
 
 		err := db.PingContext(ctx)
 		if err != nil {
-			service.Error = err.Error()
+			errorMessage := err.Error()
+
+			service.Error = errorMessage
+			span.AddAttributes(trace.StringAttribute("database-health-error", errorMessage))
+
 			service.State = web.HealthzStateUnhealthy
 		}
 

--- a/platform/database/health.go
+++ b/platform/database/health.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+	"go.opencensus.io/trace"
+
+	"github.com/fewlinesco/go-pkg/platform/web"
+)
+
+func HealthCheck(db *sqlx.DB) web.HealthzChecker {
+	return func(ctx context.Context) web.HealthzStatus {
+		ctx, span := trace.StartSpan(ctx, "database.HealthChecker")
+		span.End()
+
+		service := web.HealthzStatus{
+			Type:        "Database",
+			Description: "Check the availability of the service's database",
+			State: web.HealthzStateHealthy,
+		}
+
+		err := db.PingContext(ctx)
+		if err != nil {
+			service.Error = err.Error()
+			service.State = web.HealthzStateUnhealthy
+		}
+
+		return service
+	}
+}

--- a/platform/database/health.go
+++ b/platform/database/health.go
@@ -17,7 +17,7 @@ func HealthCheck(db *sqlx.DB) web.HealthzChecker {
 		service := web.HealthzStatus{
 			Type:        "Database",
 			Description: "Check the availability of the service's database",
-			State: web.HealthzStateHealthy,
+			State:       web.HealthzStateHealthy,
 		}
 
 		err := db.PingContext(ctx)


### PR DESCRIPTION
In this PR I created a health check handler for the connected database. I made sure it's included in every application which has a database connection.

@kdisneur mentioned that the `.Ping()` method was not realiable as it would send cached statuses from the start of the application, but trying it out locally it reported the correct status when tearing down the DB after startup.