### PR TITLE
Hide values from tracing attributes

### DIFF
--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -41,7 +41,7 @@ func Start(cfg Config) error {
 }
 
 // AddAttribute can add a string attribute to the provided span
-// Every value which is not an empty string will be changed to "[REDACTED]""
+// Every value which is not an empty string will be changed to "[REDACTED]"
 // This masks the actual value but indicates a certain key does have a value
 // Empty values will be represented by ""
 func AddAttribute(span *trace.Span, key string, value string) {

--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -53,3 +53,9 @@ func AddAttribute(span *trace.Span, key string, value string) {
 
 	span.AddAttributes(attribute)
 }
+
+// AddAttributeWithDisclosedData adds a string attribute to a span without concealing it's value
+func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
+	attribute := trace.StringAttribute(key, value)
+	span.AddAttributes(attribute)
+}

--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -39,3 +39,17 @@ func Start(cfg Config) error {
 
 	return nil
 }
+
+// AddAttribute can add a string attribute to the provided span
+// Every value which is not an empty string will be changed to "[REDACTED]""
+// This masks the actual value but indicates a certain key does have a value
+// Empty values will be represented by ""
+func AddAttribute(span *trace.Span, key string, value string) {
+	if len(value) != 0 {
+		value = "[REDACTED]"
+	}
+
+	attribute := trace.StringAttribute(key, value)
+
+	span.AddAttributes(attribute)
+}


### PR DESCRIPTION
In this PR a function is added to the tracing package which allows to add attributes to a span which value is hidden. This will ensure that no personal information is leaked via these spans but will still indicate whether or not it has a value.