### PR TITLE
Add abstraction to create spans

### DIFF
--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Span represents an individual unit of work in the system
-type Span = trace.Span
+type Span trace.Span
 
 // Config represents the JSON config applications can define in order to configure tracing
 type Config struct {
@@ -52,7 +52,7 @@ func Start(cfg Config) error {
 // Every value which is not an empty string will be changed to "[REDACTED]"
 // This masks the actual value but indicates a certain key does have a value
 // Empty values will be represented by ""
-func AddAttribute(span *Span, key string, value string) {
+func AddAttribute(span *trace.Span, key string, value string) {
 	if len(value) != 0 {
 		value = "[REDACTED]"
 	}
@@ -63,12 +63,17 @@ func AddAttribute(span *Span, key string, value string) {
 }
 
 // AddAttributeWithDisclosedData adds a string attribute to a span without concealing it's value
-func AddAttributeWithDisclosedData(span *Span, key string, value string) {
+func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
 	attribute := trace.StringAttribute(key, value)
 	span.AddAttributes(attribute)
 }
 
 // StartSpan creates a new span with the provided name
-func StartSpan(ctx context.Context, name string) (context.Context, *Span) {
+func StartSpan(ctx context.Context, name string) (context.Context, *trace.Span) {
 	return trace.StartSpan(ctx, name)
+}
+
+// EndSpan ends the provided running span
+func EndSpan(span *trace.Span) {
+	span.End()
 }

--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -1,9 +1,14 @@
 package tracing
 
 import (
+	"context"
+
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/trace"
 )
+
+// Span represents an individual unit of work in the system
+type Span = trace.Span
 
 // Config represents the JSON config applications can define in order to configure tracing
 type Config struct {
@@ -47,7 +52,7 @@ func Start(cfg Config) error {
 // Every value which is not an empty string will be changed to "[REDACTED]"
 // This masks the actual value but indicates a certain key does have a value
 // Empty values will be represented by ""
-func AddAttribute(span *trace.Span, key string, value string) {
+func AddAttribute(span *Span, key string, value string) {
 	if len(value) != 0 {
 		value = "[REDACTED]"
 	}
@@ -58,7 +63,12 @@ func AddAttribute(span *trace.Span, key string, value string) {
 }
 
 // AddAttributeWithDisclosedData adds a string attribute to a span without concealing it's value
-func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
+func AddAttributeWithDisclosedData(span *Span, key string, value string) {
 	attribute := trace.StringAttribute(key, value)
 	span.AddAttributes(attribute)
+}
+
+// StartSpan creates a new span with the provided name
+func StartSpan(ctx context.Context, name string) (context.Context, *Span) {
+	return trace.StartSpan(ctx, name)
 }


### PR DESCRIPTION
In this PR I created a small abstraction so we no longer have to reference 3rd party tracing implementations in the applications, but it's all handled in the go-pkg. This will make it easier to switch 3rd party libraries in the future if it would ever be necessary.

to be used as such: 
```
ctx, span := tracing.StartSpan(ctx, "application.SomeAction")
defer span.End()
```