### PR TITLE
Handle every 5xx HTTP errors and send them to Sentry

### DIFF
--- a/platform/web/response.go
+++ b/platform/web/response.go
@@ -32,10 +32,12 @@ func RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
 	if !ok {
 		v := ctx.Value(KeyValues).(*Values)
 
-		monitoring.CaptureException(err).Log()
-
 		err = NewErrUnmanagedResponse(v.TraceID)
 		webErr = err.(*Error)
+	}
+
+	if webErr.HTTPCode >= 500 {
+		monitoring.CaptureException(err).Log()
 	}
 
 	return Respond(ctx, w, webErr, webErr.HTTPCode)


### PR DESCRIPTION
This pull request slightly update the HTTP error handling to make every 5xx HTTP errors be sent to our error monitoring solution (Sentry).