### PR TITLE
[CU-7etgep] Add error message in traces

### DIFF
--- a/platform/web/error_middleware.go
+++ b/platform/web/error_middleware.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"net/http"
 
-	"go.opencensus.io/trace"
+	"github.com/fewlinesco/go-pkg/platform/tracing"
 )
 
 // ErrorsMiddleware is in charge of sending the JSON response to the client in case of business errors
 func ErrorsMiddleware() Middleware {
 	return func(before Handler) Handler {
 		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) error {
-			ctx, span := trace.StartSpan(ctx, "internal.web.ErrorsMiddleware")
+			ctx, span := tracing.StartSpan(ctx, "platform.web.ErrorMiddleware")
 			defer span.End()
 
 			if err := before(ctx, w, r, params); err != nil {
+				tracing.AddAttributeWithDisclosedData(span, "error", err.Error())
+
 				if err := RespondError(ctx, w, err); err != nil {
 					return err
 				}


### PR DESCRIPTION
This pull request update our `error_middleware` to add the error message (if any) inside the current span's metadata.