### PR TITLE
Add a close method on the database struct

### DIFF
--- a/platform/database/database.go
+++ b/platform/database/database.go
@@ -130,6 +130,11 @@ func (db *DB) Begin() (*Tx, error) {
 	return &Tx{tx: tx}, nil
 }
 
+// Close closes the connection to the database
+func (db *DB) Close() error {
+	return db.db.Close()
+}
+
 // SelectContext fetches a slice of elements from database.
 func (db *DB) SelectContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error {
 	var err error


### PR DESCRIPTION
The database in Go usually has a "close" method to kill the connection to it, it's currently lacking from the go-pkg