### PR TITLE
add mark as error

### DIFF
--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -68,6 +68,13 @@ func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
 	span.AddAttributes(attribute)
 }
 
+func MarkAsError(span *trace.Span, reason string) {
+	span.AddAttributes(
+		trace.BoolAttribute("error", true),
+		trace.StringAttribute("message", reason),
+	)
+}
+
 // StartSpan creates a new span with the provided name
 func StartSpan(ctx context.Context, name string) (context.Context, *trace.Span) {
 	return trace.StartSpan(ctx, name)

--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -68,6 +68,7 @@ func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
 	span.AddAttributes(attribute)
 }
 
+// MarkAsError marks the given span as erroring and set the reason as a message field
 func MarkAsError(span *trace.Span, reason string) {
 	span.AddAttributes(
 		trace.BoolAttribute("error", true),


### PR DESCRIPTION
This pull request adds a `MarkAsError(span, reason)` function to the tracing package