### PR TITLE
log panics in go pkg

### DIFF
--- a/platform/application.go
+++ b/platform/application.go
@@ -275,6 +275,7 @@ func (a *Application) StartServers(name string, serviceCheckers []web.HealthzChe
 
 	defer func() {
 		if err := recover(); err != nil {
+			a.Logger.Printf("a panic has been recovered: %v", err)
 			sentry.CurrentHub().Recover(err)
 		}
 


### PR DESCRIPTION
This PR adds 
  - logging on the main application crash recover
  - recovery middleware now wraps the panic errors and return it so we can have logs of what happened 