### PR TITLE
Allow unknown fields when decoding requests

### DIFF
--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -45,7 +45,7 @@ func init() {
 func Decode(r *http.Request, val interface{}, options DecoderOptions) error {
 	decoder := json.NewDecoder(r.Body)
 
-	if !options.AllowUnknownFields{
+	if !options.AllowUnknownFields {
 		decoder.DisallowUnknownFields()
 	}
 

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -23,6 +23,8 @@ var validate = validator.New()
 var translator *ut.UniversalTranslator
 var fieldRegex = regexp.MustCompile(`json: unknown field "([^"]+)"`)
 
+// DecoderOptions describes a set of options you can pass to alter the behaviour of the decoders
+// AllowUnknownFields ensures that the decoder can pass the json even if it contains a field unknown to the strict
 type DecoderOptions struct {
 	AllowUnknownFields bool
 }

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -15,7 +15,7 @@ type decodeWithJSONSchemaTestData struct {
 	ValidateResponse func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData)
 	JSONSchemaPath   string
 	DecoderOptions   web.DecoderOptions
-	ExpectsError    bool
+	ExpectsError     bool
 	ExpectedOutcome  expectedModel
 }
 
@@ -33,7 +33,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:  false,
+			ExpectsError:   false,
 			ExpectedOutcome: expectedModel{
 				ID:       "d43c45b0-f420-4de9-8745-6e3840ab39fd",
 				Code:     "code",
@@ -45,42 +45,42 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "c9ecb26a-20ab-4acb-b34e-444457b06b3b", "datatype": "string"}`,
 			JSONSchemaPath: "../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:  true,
+			ExpectsError:   true,
 		},
 		{
 			Name:           "when a parameter has an incorrect datatype",
 			Body:           `{"code": 1", "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:  true,
+			ExpectsError:   true,
 		},
 		{
 			Name:           "when a parameter has an incorrect enum type",
 			Body:           `{"code": "code", "id": "10fbd107-4bcf-4c91-8ee2-957e07d6109e", "datatype": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:  true,
+			ExpectsError:   true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options are empty",
 			Body:           `{"code": "code", "id": "78c8803e-ce4e-474e-97c4-7bd6d565ddca", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:  true,
+			ExpectsError:   true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "ec85bd34-67bf-4418-95cb-2616e914bfc9", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: false},
-			ExpectsError:  true,
+			ExpectsError:   true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "8321308a-4cae-4175-8c56-2db087e5ca10", "datatype": "integer", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: true},
-			ExpectsError:  false,
+			ExpectsError:   false,
 			ExpectedOutcome: expectedModel{
 				ID:       "8321308a-4cae-4175-8c56-2db087e5ca10",
 				Code:     "code",

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -15,7 +15,7 @@ type decodeWithJSONSchemaTestData struct {
 	ValidateResponse func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData)
 	JSONSchemaPath   string
 	DecoderOptions   web.DecoderOptions
-	ExpectedError    bool
+	ExpectsError    bool
 	ExpectedOutcome  expectedModel
 }
 
@@ -33,7 +33,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  false,
+			ExpectsError:  false,
 			ExpectedOutcome: expectedModel{
 				ID:       "d43c45b0-f420-4de9-8745-6e3840ab39fd",
 				Code:     "code",
@@ -45,42 +45,42 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "c9ecb26a-20ab-4acb-b34e-444457b06b3b", "datatype": "string"}`,
 			JSONSchemaPath: "../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  true,
+			ExpectsError:  true,
 		},
 		{
 			Name:           "when a parameter has an incorrect datatype",
 			Body:           `{"code": 1", "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  true,
+			ExpectsError:  true,
 		},
 		{
 			Name:           "when a parameter has an incorrect enum type",
 			Body:           `{"code": "code", "id": "10fbd107-4bcf-4c91-8ee2-957e07d6109e", "datatype": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  true,
+			ExpectsError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options are empty",
 			Body:           `{"code": "code", "id": "78c8803e-ce4e-474e-97c4-7bd6d565ddca", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  true,
+			ExpectsError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "ec85bd34-67bf-4418-95cb-2616e914bfc9", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: false},
-			ExpectedError:  true,
+			ExpectsError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "8321308a-4cae-4175-8c56-2db087e5ca10", "datatype": "integer", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: true},
-			ExpectedError:  false,
+			ExpectsError:  false,
 			ExpectedOutcome: expectedModel{
 				ID:       "8321308a-4cae-4175-8c56-2db087e5ca10",
 				Code:     "code",
@@ -102,7 +102,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 
 			var result expectedModel
 			if err := web.DecodeWithJSONSchema(request, &result, tc.JSONSchemaPath, tc.DecoderOptions); err != nil {
-				if !tc.ExpectedError {
+				if !tc.ExpectsError {
 					t.Fatalf("the decoder returned an error message but this was not expected: %v", err)
 				}
 				return

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -14,14 +14,14 @@ type decodeWithJSONSchemaTestData struct {
 	Body             string
 	ValidateResponse func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData)
 	JSONSchemaPath   string
-	DecoderOptions web.DecoderOptions
-	ExpectedError bool
-	ExpectedOutcome expectedModel
+	DecoderOptions   web.DecoderOptions
+	ExpectedError    bool
+	ExpectedOutcome  expectedModel
 }
 
 type expectedModel struct {
 	ID       string `json:"id"`
-	Code     string    `json:"code"`
+	Code     string `json:"code"`
 	DataType string `json:"datatype"`
 }
 
@@ -33,7 +33,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError: false,
+			ExpectedError:  false,
 			ExpectedOutcome: expectedModel{
 				ID:       "d43c45b0-f420-4de9-8745-6e3840ab39fd",
 				Code:     "code",
@@ -45,42 +45,42 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "c9ecb26a-20ab-4acb-b34e-444457b06b3b", "datatype": "string"}`,
 			JSONSchemaPath: "../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError: true,
+			ExpectedError:  true,
 		},
 		{
 			Name:           "when a parameter has an incorrect datatype",
 			Body:           `{"code": 1", "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError: true,
+			ExpectedError:  true,
 		},
 		{
 			Name:           "when a parameter has an incorrect enum type",
 			Body:           `{"code": "code", "id": "10fbd107-4bcf-4c91-8ee2-957e07d6109e", "datatype": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError: true,
+			ExpectedError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options are empty",
 			Body:           `{"code": "code", "id": "78c8803e-ce4e-474e-97c4-7bd6d565ddca", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError: true,
+			ExpectedError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "ec85bd34-67bf-4418-95cb-2616e914bfc9", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: false},
-			ExpectedError: true,
+			ExpectedError:  true,
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "8321308a-4cae-4175-8c56-2db087e5ca10", "datatype": "integer", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: true},
-			ExpectedError: false,
+			ExpectedError:  false,
 			ExpectedOutcome: expectedModel{
 				ID:       "8321308a-4cae-4175-8c56-2db087e5ca10",
 				Code:     "code",

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,59 +14,83 @@ type decodeWithJSONSchemaTestData struct {
 	Body             string
 	ValidateResponse func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData)
 	JSONSchemaPath   string
+	DecoderOptions web.DecoderOptions
+	ExpectedError bool
+	ExpectedOutcome expectedModel
+}
+
+type expectedModel struct {
+	ID       string `json:"id"`
+	Code     string    `json:"code"`
+	DataType string `json:"datatype"`
 }
 
 func TestDecodeWithJSONSchema(t *testing.T) {
-	type expectedModel struct {
-		ID       string `json:"id"`
-		Code     int    `json:"code"`
-		DataType string `json:"datatype"`
-	}
 
 	tcs := []decodeWithJSONSchemaTestData{
 		{
 			Name:           "when the decoding happens without an error",
-			Body:           `{"code": 1, "id": "1", "datatype": "string"}`,
+			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
-			ValidateResponse: func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData) {
-				if outcome != nil {
-					t.Fatalf("did not expect the function to return an error, but got: %+v", outcome)
-				}
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError: false,
+			ExpectedOutcome: expectedModel{
+				ID:       "d43c45b0-f420-4de9-8745-6e3840ab39fd",
+				Code:     "code",
+				DataType: "integer",
 			},
 		},
 		{
 			Name:           "when the path to the json schema is incorrect",
-			Body:           `{"code": 1, "id": "1", "datatype": "string"}`,
+			Body:           `{"code": "code", "id": "c9ecb26a-20ab-4acb-b34e-444457b06b3b", "datatype": "string"}`,
 			JSONSchemaPath: "../../testdata/json-schema/json_schema_with_definition.json",
-			ValidateResponse: func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData) {
-				if outcome == nil {
-					t.Fatalf("expected an error but got nil")
-				}
-			},
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError: true,
 		},
 		{
 			Name:           "when a parameter has an incorrect datatype",
-			Body:           `{"code": 1, "id": 1, "datatype": "string"}`,
+			Body:           `{"code": 1", "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
-			ValidateResponse: func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData) {
-				if outcome == nil {
-					t.Fatalf("expected an error but got nil")
-				}
-			},
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError: true,
 		},
 		{
 			Name:           "when a parameter has an incorrect enum type",
-			Body:           `{"code": 1, "id": "1", "datatype": "hello"}`,
+			Body:           `{"code": "code", "id": "10fbd107-4bcf-4c91-8ee2-957e07d6109e", "datatype": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
-			ValidateResponse: func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData) {
-				if outcome == nil {
-					t.Fatalf("expected an error but got nil")
-				}
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError: true,
+		},
+		{
+			Name:           "when the json has an unknown field and the decoder options are empty",
+			Body:           `{"code": "code", "id": "78c8803e-ce4e-474e-97c4-7bd6d565ddca", "datatype": "string", "unknown_field": "hello"}`,
+			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError: true,
+		},
+		{
+			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
+			Body:           `{"code": "code", "id": "ec85bd34-67bf-4418-95cb-2616e914bfc9", "datatype": "string", "unknown_field": "hello"}`,
+			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
+			DecoderOptions: web.DecoderOptions{AllowUnknownFields: false},
+			ExpectedError: true,
+		},
+		{
+			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
+			Body:           `{"code": "code", "id": "8321308a-4cae-4175-8c56-2db087e5ca10", "datatype": "integer", "unknown_field": "hello"}`,
+			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
+			DecoderOptions: web.DecoderOptions{AllowUnknownFields: true},
+			ExpectedError: false,
+			ExpectedOutcome: expectedModel{
+				ID:       "8321308a-4cae-4175-8c56-2db087e5ca10",
+				Code:     "code",
+				DataType: "integer",
 			},
 		},
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 
 			request, err := http.NewRequest(http.MethodPut, "http://localhost:30000", strings.NewReader(tc.Body))
@@ -75,7 +100,17 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 
 			request.Header.Set("Content-Type", "application/json")
 
-			tc.ValidateResponse(t, web.DecodeWithJSONSchema(request, &expectedModel{}, tc.JSONSchemaPath), tc)
+			var result expectedModel
+			if err := web.DecodeWithJSONSchema(request, &result, tc.JSONSchemaPath, tc.DecoderOptions); err != nil {
+				if !tc.ExpectedError {
+					t.Fatalf("the decoder returned an error message but this was not expected: %v", err)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(result, tc.ExpectedOutcome) {
+				t.Fatalf("the expected outcome and result don't match.\n\tExpected: %+v\n\tReceived: %v", tc.ExpectedOutcome, result)
+			}
 		})
 	}
 }

--- a/testdata/json-schema/json_schema_with_definition.json
+++ b/testdata/json-schema/json_schema_with_definition.json
@@ -15,11 +15,11 @@
       "type": "string"
     },
     "code": {
-      "type": "integer"
+      "type": "string"
     },
     "datatype": {
       "$ref": "#/definitions/datatypes"
     }
   },
-  "required": ["code", "datatype"]
+  "required": ["id", "code", "datatype"]
 }

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -34,6 +34,6 @@ type LRUCache interface {
 	// Clears all cache entries.
 	Purge()
 
-  // Resizes cache, returning number evicted
-  Resize(int) int
+	// Resizes cache, returning number evicted
+	Resize(int) int
 }

--- a/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
+++ b/vendor/github.com/uber/jaeger-client-go/thrift/protocol.go
@@ -88,9 +88,9 @@ func SkipDefaultDepth(prot TProtocol, typeId TType) (err error) {
 
 // Skips over the next data element from the provided input TProtocol object.
 func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
-	
-    if maxDepth <= 0 {
-		return NewTProtocolExceptionWithType( DEPTH_LIMIT, errors.New("Depth limit exceeded"))
+
+	if maxDepth <= 0 {
+		return NewTProtocolExceptionWithType(DEPTH_LIMIT, errors.New("Depth limit exceeded"))
 	}
 
 	switch fieldType {

--- a/vendor/github.com/uber/jaeger-client-go/thrift/protocol_exception.go
+++ b/vendor/github.com/uber/jaeger-client-go/thrift/protocol_exception.go
@@ -60,7 +60,7 @@ func NewTProtocolException(err error) TProtocolException {
 	if err == nil {
 		return nil
 	}
-	if e,ok := err.(TProtocolException); ok {
+	if e, ok := err.(TProtocolException); ok {
 		return e
 	}
 	if _, ok := err.(base64.CorruptInputError); ok {
@@ -75,4 +75,3 @@ func NewTProtocolExceptionWithType(errType int, err error) TProtocolException {
 	}
 	return &tProtocolException{errType, err.Error()}
 }
-

--- a/vendor/github.com/uber/jaeger-client-go/thrift/rich_transport.go
+++ b/vendor/github.com/uber/jaeger-client-go/thrift/rich_transport.go
@@ -66,4 +66,3 @@ func writeByte(w io.Writer, c byte) error {
 	_, err := w.Write(v[0:1])
 	return err
 }
-

--- a/vendor/github.com/uber/jaeger-client-go/thrift/transport.go
+++ b/vendor/github.com/uber/jaeger-client-go/thrift/transport.go
@@ -34,7 +34,6 @@ type ReadSizeProvider interface {
 	RemainingBytes() (num_bytes uint64)
 }
 
-
 // Encapsulates the I/O layer
 type TTransport interface {
 	io.ReadWriteCloser
@@ -52,7 +51,6 @@ type stringWriter interface {
 	WriteString(s string) (n int, err error)
 }
 
-
 // This is "enchanced" transport with extra capabilities. You need to use one of these
 // to construct protocol.
 // Notably, TSocket does not implement this interface, and it is always a mistake to use
@@ -65,4 +63,3 @@ type TRichTransport interface {
 	Flusher
 	ReadSizeProvider
 }
-

--- a/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
+++ b/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
@@ -130,10 +130,10 @@ func (p *JsonPointer) implementation(i *implStruct) {
 				node = v[decodedToken]
 				if isLastToken && i.mode == "SET" {
 					v[decodedToken] = i.setInValue
-				} else if isLastToken && i.mode =="DEL" {
-					delete(v,decodedToken)
+				} else if isLastToken && i.mode == "DEL" {
+					delete(v, decodedToken)
 				}
-			} else if (isLastToken && i.mode == "SET") {
+			} else if isLastToken && i.mode == "SET" {
 				v[decodedToken] = i.setInValue
 			} else {
 				i.outError = fmt.Errorf("Object has no key '%s'", decodedToken)
@@ -160,7 +160,7 @@ func (p *JsonPointer) implementation(i *implStruct) {
 			node = v[tokenIndex]
 			if isLastToken && i.mode == "SET" {
 				v[tokenIndex] = i.setInValue
-			}  else if isLastToken && i.mode =="DEL" {
+			} else if isLastToken && i.mode == "DEL" {
 				v[tokenIndex] = v[len(v)-1]
 				v[len(v)-1] = nil
 				v = v[:len(v)-1]

--- a/vendor/google.golang.org/protobuf/internal/impl/merge_gen.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/merge_gen.go
@@ -6,8 +6,6 @@
 
 package impl
 
-import ()
-
 func mergeBool(dst, src pointer, _ *coderFieldInfo, _ mergeOptions) {
 	*dst.Bool() = *src.Bool()
 }

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -95,7 +95,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 
 	// [Go] This function was changed to guarantee the requested length size at EOF.
 	// The fact we need to do this is pretty awful, but the description above implies
-	// for that to be the case, and there are tests 
+	// for that to be the case, and there are tests
 
 	// If the EOF flag is set and the raw buffer is empty, do nothing.
 	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -180,7 +180,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
 				if err == nil {
 					if true || intv == int64(int(intv)) {
 						return yaml_INT_TAG, int(intv)

--- a/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/vendor/gopkg.in/yaml.v2/sorter.go
@@ -52,7 +52,7 @@ func (l keyList) Less(i, j int) bool {
 		var ai, bi int
 		var an, bn int64
 		if ar[i] == '0' || br[i] == '0' {
-			for j := i-1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
+			for j := i - 1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
 				if ar[j] != '0' {
 					an = 1
 					bn = 1


### PR DESCRIPTION
In this PR I add the option to pass on decoder options so that if the json would have unknown fields, the parser would not return an error. 