### PR TITLE
Return a different error when required keys are missing

### DIFF
--- a/platform/web/errors.go
+++ b/platform/web/errors.go
@@ -78,7 +78,7 @@ func NewErrNotFoundResponse() error {
 	}
 }
 
-// newErrUnmarshallableJSON is returned if we are unable to unmarshal the request body to a struct
+// NewErrUnmarshallableJSON is returned if we are unable to unmarshal the request body to a struct
 func NewErrUnmarshallableJSON() error {
 	return &Error{
 		HTTPCode:     http.StatusBadRequest,
@@ -86,7 +86,7 @@ func NewErrUnmarshallableJSON() error {
 	}
 }
 
-// newErrMissingRequestBody is returned when there is no body present in the request
+// NewErrMissingRequestBody is returned when there is no body present in the request
 func NewErrMissingRequestBody() error {
 	return &Error{
 		HTTPCode:     http.StatusBadRequest,
@@ -94,7 +94,7 @@ func NewErrMissingRequestBody() error {
 	}
 }
 
-// newErrInvalidRequest is returned when the request payload is ill-formed
+// NewErrInvalidRequestBodyContent is returned when the request payload is ill-formed
 // and can't be validated using the JSON schema
 func NewErrInvalidRequestBodyContent(errorDetails ErrorDetails) error {
 	return &Error{
@@ -104,7 +104,7 @@ func NewErrInvalidRequestBodyContent(errorDetails ErrorDetails) error {
 	}
 }
 
-// newErrInvalidJSONSchemaFilePath is returned when the file path provided
+// NewErrInvalidJSONSchemaFilePath is returned when the file path provided
 // to the DecodeWithJSONSchema function contains an error
 func NewErrInvalidJSONSchemaFilePath() error {
 	return &Error{

--- a/platform/web/errors.go
+++ b/platform/web/errors.go
@@ -79,7 +79,7 @@ func NewErrNotFoundResponse() error {
 }
 
 // newErrUnmarshallableJSON is returned if we are unable to unmarshal the request body to a struct
-func newErrUnmarshallableJSON() error {
+func NewErrUnmarshallableJSON() error {
 	return &Error{
 		HTTPCode:     http.StatusBadRequest,
 		ErrorMessage: UnmarshallableJSONMessage,
@@ -87,7 +87,7 @@ func newErrUnmarshallableJSON() error {
 }
 
 // newErrMissingRequestBody is returned when there is no body present in the request
-func newErrMissingRequestBody() error {
+func NewErrMissingRequestBody() error {
 	return &Error{
 		HTTPCode:     http.StatusBadRequest,
 		ErrorMessage: MissingBodyMessage,
@@ -96,7 +96,7 @@ func newErrMissingRequestBody() error {
 
 // newErrInvalidRequest is returned when the request payload is ill-formed
 // and can't be validated using the JSON schema
-func newErrInvalidRequestBodyContent(errorDetails ErrorDetails) error {
+func NewErrInvalidRequestBodyContent(errorDetails ErrorDetails) error {
 	return &Error{
 		ErrorMessage: InvalidRequestBodyContentMessage,
 		HTTPCode:     http.StatusBadRequest,
@@ -106,7 +106,7 @@ func newErrInvalidRequestBodyContent(errorDetails ErrorDetails) error {
 
 // newErrInvalidJSONSchemaFilePath is returned when the file path provided
 // to the DecodeWithJSONSchema function contains an error
-func newErrInvalidJSONSchemaFilePath() error {
+func NewErrInvalidJSONSchemaFilePath() error {
 	return &Error{
 		ErrorMessage: InvalidJSONSchemaFilePath,
 		HTTPCode:     http.StatusInternalServerError,

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -74,7 +74,7 @@ func DecodeWithJSONSchema(request *http.Request, model interface{}, filePath str
 
 		for _, desc := range result.Errors() {
 			if desc.Type() == "required" {
-				property , ok :=  desc.Details()["property"]
+				property, ok := desc.Details()["property"]
 				if !ok {
 					property = desc.Field()
 				}

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -55,7 +55,7 @@ func DecodeWithJSONSchema(request *http.Request, model interface{}, filePath str
 
 	_, rootFile, _, ok := runtime.Caller(1)
 	if !ok {
-		return fmt.Errorf("%w", newErrInvalidJSONSchemaFilePath())
+		return fmt.Errorf("%w", NewErrInvalidJSONSchemaFilePath())
 	}
 
 	filePath = path.Join(path.Dir(rootFile), filePath)
@@ -75,7 +75,7 @@ func DecodeWithJSONSchema(request *http.Request, model interface{}, filePath str
 			errorDetails[desc.Field()] = desc.Description()
 		}
 
-		return fmt.Errorf("%w", newErrInvalidRequestBodyContent(errorDetails))
+		return fmt.Errorf("%w", NewErrInvalidRequestBodyContent(errorDetails))
 	}
 
 	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
@@ -101,11 +101,11 @@ func decode(r *http.Request, val interface{}, options DecoderOptions) error {
 				e.Field: fmt.Sprintf("%s must be a %s", e.Field, e.Type.String()),
 			}))
 		case *json.SyntaxError:
-			return fmt.Errorf("%v: %w", err, newErrUnmarshallableJSON())
+			return fmt.Errorf("%v: %w", err, NewErrUnmarshallableJSON())
 		}
 
 		if err.Error() == "EOF" {
-			return fmt.Errorf("%v: %w", err, newErrMissingRequestBody())
+			return fmt.Errorf("%v: %w", err, NewErrMissingRequestBody())
 		}
 
 		if strings.Contains(err.Error(), "json: unknown field") {
@@ -117,10 +117,10 @@ func decode(r *http.Request, val interface{}, options DecoderOptions) error {
 			}))
 		}
 
-		return fmt.Errorf("%T, %v: %w", err, err, newErrUnmarshallableJSON())
+		return fmt.Errorf("%T, %v: %w", err, err, NewErrUnmarshallableJSON())
 	}
 
-	return Validate(val, newErrInvalidRequestBodyContent)
+	return Validate(val, NewErrInvalidRequestBodyContent)
 }
 
 // Validate checks the struct is valid based on gopkg.in/go-playground/validator.v9 validation tags.

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -96,6 +96,25 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 				DataType: "integer",
 			},
 		},
+		{
+			Name:           "it returns a bad request reponse when a required key is missing",
+			Body:           `{"code": "code", "datatype": "integer"}`,
+			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError:  web.NewErrBadRequestResponse(web.ErrorDetails{
+				"id": "id is required",
+			}),
+		},
+		{
+			Name:           "it returns a bad request reponse when a required key is missing and there is an issue with another property",
+			Body:           `{"code": 5, "datatype": "integer"}`,
+			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
+			DecoderOptions: web.DecoderOptions{},
+			ExpectedError:  web.NewErrBadRequestResponse(web.ErrorDetails{
+				"id": "id is required",
+				"code": "Invalid type. Expected: string, given: integer",
+			}),
+		},
 	}
 
 	for _, tc := range tcs {

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -101,7 +101,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  web.NewErrBadRequestResponse(web.ErrorDetails{
+			ExpectedError: web.NewErrBadRequestResponse(web.ErrorDetails{
 				"id": "id is required",
 			}),
 		},
@@ -110,8 +110,8 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": 5, "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  web.NewErrBadRequestResponse(web.ErrorDetails{
-				"id": "id is required",
+			ExpectedError: web.NewErrBadRequestResponse(web.ErrorDetails{
+				"id":   "id is required",
 				"code": "Invalid type. Expected: string, given: integer",
 			}),
 		},

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"errors"
 	"net/http"
 	"reflect"
 	"strings"
@@ -15,7 +16,7 @@ type decodeWithJSONSchemaTestData struct {
 	ValidateResponse func(testProvider *testing.T, outcome error, data decodeWithJSONSchemaTestData)
 	JSONSchemaPath   string
 	DecoderOptions   web.DecoderOptions
-	ExpectsError     bool
+	ExpectedError    error
 	ExpectedOutcome  expectedModel
 }
 
@@ -33,7 +34,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:   false,
+			ExpectedError:  nil,
 			ExpectedOutcome: expectedModel{
 				ID:       "d43c45b0-f420-4de9-8745-6e3840ab39fd",
 				Code:     "code",
@@ -45,42 +46,50 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "c9ecb26a-20ab-4acb-b34e-444457b06b3b", "datatype": "string"}`,
 			JSONSchemaPath: "../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:   true,
+			ExpectedError:  web.NewErrBadRequestResponse(nil),
 		},
 		{
 			Name:           "when a parameter has an incorrect datatype",
-			Body:           `{"code": 1", "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
+			Body:           `{"code": 1, "id": "815b73a1-3d89-4c68-a4d8-1f36c091a533", "datatype": "string"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:   true,
+			ExpectedError: web.NewErrInvalidRequestBodyContent(web.ErrorDetails{
+				"code": "Invalid type. Expected: string, given: integer",
+			}),
 		},
 		{
 			Name:           "when a parameter has an incorrect enum type",
 			Body:           `{"code": "code", "id": "10fbd107-4bcf-4c91-8ee2-957e07d6109e", "datatype": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:   true,
+			ExpectedError: web.NewErrInvalidRequestBodyContent(web.ErrorDetails{
+				"datatype": `datatype must be one of the following: "string", "boolean", "localizedString", "integer", "number"`,
+			}),
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options are empty",
 			Body:           `{"code": "code", "id": "78c8803e-ce4e-474e-97c4-7bd6d565ddca", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectsError:   true,
+			ExpectedError: web.NewErrBadRequestResponse(web.ErrorDetails{
+				"unknown_field": "unknown_field field is not allowed",
+			}),
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "ec85bd34-67bf-4418-95cb-2616e914bfc9", "datatype": "string", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: false},
-			ExpectsError:   true,
+			ExpectedError: web.NewErrBadRequestResponse(web.ErrorDetails{
+				"unknown_field": "unknown_field field is not allowed",
+			}),
 		},
 		{
 			Name:           "when the json has an unknown field and the decoder options specify it should not allow unknown fields ",
 			Body:           `{"code": "code", "id": "8321308a-4cae-4175-8c56-2db087e5ca10", "datatype": "integer", "unknown_field": "hello"}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{AllowUnknownFields: true},
-			ExpectsError:   false,
+			ExpectedError:  nil,
 			ExpectedOutcome: expectedModel{
 				ID:       "8321308a-4cae-4175-8c56-2db087e5ca10",
 				Code:     "code",
@@ -102,14 +111,43 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 
 			var result expectedModel
 			if err := web.DecodeWithJSONSchema(request, &result, tc.JSONSchemaPath, tc.DecoderOptions); err != nil {
-				if !tc.ExpectsError {
-					t.Fatalf("the decoder returned an error message but this was not expected: %v", err)
+				if tc.ExpectedError == nil {
+					t.Fatalf("the request body failed the validation but the test did not expect this: %v", err)
 				}
+
+				returnedWebError, ok := errors.Unwrap(err).(*web.Error)
+				if !ok {
+					t.Fatalf("the decoder should always return a web error but it did not: %v", err)
+				}
+
+				expectedWebError, ok := tc.ExpectedError.(*web.Error)
+				if !ok {
+					t.Fatalf("the expected error should be a web error but it was unable to cast to one: %v", tc.ExpectedError)
+				}
+
+				if expectedWebError.Code != returnedWebError.Code {
+					t.Fatalf("the returned error's code does not match the expectation.\n\tExpected: %+v\n\tReturned: %+v", expectedWebError.Code, returnedWebError.Code)
+				}
+
+				if expectedWebError.Message != returnedWebError.Message {
+					t.Fatalf("the returned error's message does not match the expectation.\n\tExpected: %+v\n\tReturned: %+v", expectedWebError.Message, returnedWebError.Message)
+				}
+
+				if len(expectedWebError.Details) != len(returnedWebError.Details) {
+					t.Fatalf("the returned error's number of details does not match the expectation.\n\tExpected: %+v\n\tReturned: %+v", expectedWebError.Details, returnedWebError.Details)
+				}
+
+				for key, message := range returnedWebError.Details {
+					if expectedMessage, ok := expectedWebError.Details[key]; !ok || expectedMessage != message {
+						t.Fatalf("the error message  detail for the key: '%s' does not match the expectation.\n\tExpected message: %s\n\tReturned message: %s", key, expectedMessage, message)
+					}
+				}
+
 				return
 			}
 
 			if !reflect.DeepEqual(result, tc.ExpectedOutcome) {
-				t.Fatalf("the expected outcome and result don't match.\n\tExpected: %+v\n\tReceived: %v", tc.ExpectedOutcome, result)
+				t.Fatalf("the expected outcome and result don't match.\n\tExpected: %+v\n\tReceived: %+v", tc.ExpectedOutcome, result)
 			}
 		})
 	}

--- a/testdata/json-schema/json_schema_with_definition.json
+++ b/testdata/json-schema/json_schema_with_definition.json
@@ -19,6 +19,9 @@
     },
     "datatype": {
       "$ref": "#/definitions/datatypes"
+    },
+    "title": {
+      "type": "string"
     }
   },
   "required": ["id", "code", "datatype"]


### PR DESCRIPTION
When validating a request body by a json schema we would return a 422 error when a required key is missing from the request. This should be a 400, in lign with adding an unknown field.

This addition will check if the error found is because a required property is not present in the body and return the error meant for a 400 response in case