### PR TITLE
Adjust decoder errors

### DIFF
--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -73,19 +73,20 @@ func DecodeWithJSONSchema(request *http.Request, model interface{}, filePath str
 		requestContentErrorDetails := make(ErrorDetails)
 
 		for _, desc := range result.Errors() {
-			if desc.Type() == "required" {
-				property, ok := desc.Details()["property"]
-				if !ok {
-					property = desc.Field()
+			propertyName := desc.Field()
+			if propertyName == "(root)" {
+				details, ok := desc.Details()["property"]
+				if ok {
+					propertyName = fmt.Sprintf("%v", details)
 				}
+			}
 
-				requiredProperty := fmt.Sprintf("%s", property)
-
-				requiredPropertyErrors[requiredProperty] = desc.Description()
+			if desc.Type() == "required" {
+				requiredPropertyErrors[propertyName] = desc.Description()
 				continue
 			}
 
-			requestContentErrorDetails[desc.Field()] = desc.Description()
+			requestContentErrorDetails[propertyName] = desc.Description()
 		}
 
 		if len(requiredPropertyErrors) > 0 {

--- a/platform/web/tests/decode_with_json_schema_test.go
+++ b/platform/web/tests/decode_with_json_schema_test.go
@@ -134,7 +134,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer", "name": {"fr-FR": "another test"}}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  web.NewErrBadRequestResponse(web.ErrorDetails{
+			ExpectedError: web.NewErrBadRequestResponse(web.ErrorDetails{
 				"name": "en-US is required",
 			}),
 		},
@@ -143,7 +143,7 @@ func TestDecodeWithJSONSchema(t *testing.T) {
 			Body:           `{"code": "code", "id": "d43c45b0-f420-4de9-8745-6e3840ab39fd", "datatype": "integer", "name": {"en-US": "this is a test", "French": "ceci est une test"}}`,
 			JSONSchemaPath: "../../../testdata/json-schema/json_schema_with_definition.json",
 			DecoderOptions: web.DecoderOptions{},
-			ExpectedError:  web.NewErrInvalidRequestBodyContent(web.ErrorDetails{
+			ExpectedError: web.NewErrInvalidRequestBodyContent(web.ErrorDetails{
 				"name": "Additional property French is not allowed",
 			}),
 		},

--- a/testdata/json-schema/json_schema_with_definition.json
+++ b/testdata/json-schema/json_schema_with_definition.json
@@ -11,6 +11,19 @@
     }
   },
   "properties": {
+    "name": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z]+-[a-zA-Z]+$": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "en-US"
+      ]
+    },
     "id": {
       "type": "string"
     },


### PR DESCRIPTION
When implementing the previous fix I noticed that the localized string's error messages were not correct. So this should fix it and I added some tests to ensure that it now works.