### PR TITLE
Tracing/fix mark as error

### DIFF
--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -72,8 +72,12 @@ func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
 func MarkAsError(span *trace.Span, reason string) {
 	span.AddAttributes(
 		trace.BoolAttribute("error", true),
-		trace.StringAttribute("message", reason),
 	)
+	// status code 2 is understood by the otel-collector as an error and is necessary to have our spans marked as errors after translation to the otel format
+	span.SetStatus(trace.Status{
+		Code:    2,
+		Message: reason,
+	})
 }
 
 // StartSpan creates a new span with the provided name

--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -71,7 +71,7 @@ func AddAttributeWithDisclosedData(span *trace.Span, key string, value string) {
 // MarkAsError marks the given span as erroring and set the reason as a message field
 func MarkAsError(span *trace.Span, reason string) {
 	span.AddAttributes(
-		trace.BoolAttribute("error", true),
+		trace.StringAttribute("error.message", reason),
 	)
 	// status code 2 is understood by the otel-collector as an error and is necessary to have our spans marked as errors after translation to the otel format
 	span.SetStatus(trace.Status{


### PR DESCRIPTION
Fix `tracing.MarkAsError()` for use in both Lightstep and Jaeger. The error tag is automatically set via the status so it is not necessary to set manually.
The message is the status seems ignored by Otel so I've readded it to the attributes as `error.message` to have it in Lightstep.

Example trace in Lightstep with the changes:

<img width="628" alt="Screenshot 2020-12-21 at 16 56 46" src="https://user-images.githubusercontent.com/44224782/102795753-8b46ac80-43ad-11eb-9a3f-28fed4267de2.png">
