### PR TITLE
Ensure that the new interfaces can have migrations and health checks

### DIFF
--- a/platform/application.go
+++ b/platform/application.go
@@ -213,7 +213,7 @@ func (c *ClassicalApplication) Start(name string, arguments []string, router *we
 		arguments = arguments[1:]
 	}
 
-	defaultServiceCheckers := []web.HealthzChecker{database.HealthCheck(c.Database)}
+	defaultServiceCheckers := []web.HealthzChecker{c.Database.HealthCheck("database")}
 	serviceCheckers = append(defaultServiceCheckers, serviceCheckers...)
 
 	switch command {
@@ -234,7 +234,7 @@ func (c *CQRSApplication) Start(name string, arguments []string, router *web.Rou
 		arguments = arguments[1:]
 	}
 
-	defaultServiceCheckers := []web.HealthzChecker{database.ReadDBHealthCheck(c.ReadDatabase), database.WriteDBHealthCheck(c.WriteDatabase)}
+	defaultServiceCheckers := []web.HealthzChecker{c.ReadDatabase.HealthCheck("read-database"), c.WriteDatabase.HealthCheck("write-database")}
 	serviceCheckers = append(defaultServiceCheckers, serviceCheckers...)
 
 	switch command {

--- a/platform/database/database.go
+++ b/platform/database/database.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/GuiaBolso/darwin"
 	"github.com/fewlinesco/go-pkg/platform/metrics"
+	"github.com/fewlinesco/go-pkg/platform/web"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
@@ -68,6 +69,7 @@ type WriteDB interface {
 	ExecContext(ctx context.Context, statement string, arg ...interface{}) (sql.Result, error)
 	NamedExecContext(ctx context.Context, statement string, arg interface{}) (sql.Result, error)
 	PingContext(ctx context.Context) error
+	HealthCheck(string) web.HealthzChecker
 }
 
 // ReadDB describes a set of methods which can be performed on a DB with read-only permissions
@@ -79,6 +81,7 @@ type ReadDB interface {
 	SelectMultipleContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error
 	GetContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error
 	PingContext(ctx context.Context) error
+	HealthCheck(string) web.HealthzChecker
 }
 
 // DB is a generic interface for database interaction
@@ -92,6 +95,7 @@ type DB interface {
 	SelectMultipleContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error
 	GetContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error
 	PingContext(ctx context.Context) error
+	HealthCheck(string) web.HealthzChecker
 }
 
 // Tx is a generic interface for database transactions

--- a/platform/database/health.go
+++ b/platform/database/health.go
@@ -10,18 +10,13 @@ import (
 )
 
 // HealthCheck is a generic health checker in charge of checking the database availability
-func HealthCheck(db DB) web.HealthzChecker {
-	return genericHealthCheck("database")(db)
+func (db *prodDB) HealthCheck(dbName string) web.HealthzChecker {
+	return genericHealthCheck(dbName)(db)
 }
 
-// ReadDBHealthCheck is a generic health checker in charge of checking the read database availability
-func ReadDBHealthCheck(db DB) web.HealthzChecker {
-	return genericHealthCheck("read-database")(db)
-}
-
-// WriteDBHealthCheck is a generic health checker in charge of checking the write database availability
-func WriteDBHealthCheck(db DB) web.HealthzChecker {
-	return genericHealthCheck("write-database")(db)
+// HealthCheck is a generic health checker in charge of checking the database availability
+func (db *sandboxDB) HealthCheck(dbName string) web.HealthzChecker {
+	return genericHealthCheck(dbName)(db)
 }
 
 func genericHealthCheck(databaseName string) func(db DB) web.HealthzChecker {

--- a/platform/database/migration.go
+++ b/platform/database/migration.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Migrate is a helper function in charge of running pending migrations
-func Migrate(db DB, migrations []darwin.Migration) error {
+func Migrate(db WriteDB, migrations []darwin.Migration) error {
 	driver := db.NewGenericDriver(darwin.PostgresDialect{})
 
 	d := darwin.New(driver, migrations, nil)


### PR DESCRIPTION
In this PR I ensure that the WriteDB interface can execute migrations and that we can have health check handlers on read and writeDB's with a custom name.