### PR TITLE
Improve the Listen() and Serve() API for the APIServer.

### DIFF
--- a/platform/web/api_server.go
+++ b/platform/web/api_server.go
@@ -26,7 +26,7 @@ type APIServerError struct {
 	Error  error
 }
 
-// Listen creates a tcp listener for the server on its configured address meant to be passed to APIServer.Serve
+// Listen creates a tcp listener for the server on its configured address
 func (s *APIServer) Listen() error {
 	listener, err := net.Listen("tcp", s.Config.Address)
 	if err != nil {


### PR DESCRIPTION
Added a `Listener` field to the `APIServer` struct.
`APIServer.Listen()` now initialize the listener inside the struct and `APIServer.Serve()` uses that listener to start serving requests without having to be passed a listener explicitely.