### PR TITLE
Add helpers to add span context to requests

### DIFF
--- a/platform/tracing/opentracing.go
+++ b/platform/tracing/opentracing.go
@@ -2,8 +2,10 @@ package tracing
 
 import (
 	"context"
+	"net/http"
 
 	"contrib.go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
 )
 
@@ -88,4 +90,18 @@ func StartSpan(ctx context.Context, name string) (context.Context, *trace.Span) 
 // EndSpan ends the provided running span
 func EndSpan(span *trace.Span) {
 	span.End()
+}
+
+// SpanContextToRequest adds the provided span's information to the given request.
+// This is useful for requests to other services so we can have distributed traces
+func SpanContextToRequest(span *trace.Span, req *http.Request) {
+	format := b3.HTTPFormat{}
+	format.SpanContextToRequest(span.SpanContext(), req)
+}
+
+// SpanContextFromRequest gets any span context information from the request
+// This is useful for handling requests from other services so we can have distributed traces
+func SpanContextFromRequest(req *http.Request) (trace.SpanContext, bool) {
+	format := b3.HTTPFormat{}
+	return format.SpanContextFromRequest(req)
 }


### PR DESCRIPTION
In this PR I add some helpers to add span context to requests.

There is already a HTTP client with a roundtripper to do this in the package, but there were 2 reasons why I don't like it for the feature in the event service:

- The header itself is a gibberish concatenation of the ID's and some other things, making it super hard to test and read
- The header would only be added right before the request is made, so it would not actually be saved in the request_attempts table in the event service, which would be super nice for debugging

Therefore I decided to use it with the `b3` format which is still widely accepted in the Otel collector universe. We can add the headers when we want, and they are in a nice format being: `X-B3-TraceId`, `X-B3-SpanId` 