### PR TITLE
Fix the sandbox SelectMultipleContext Implementation

### DIFF
--- a/platform/database/sandbox.go
+++ b/platform/database/sandbox.go
@@ -91,9 +91,8 @@ func (db *sandboxDB) SelectMultipleContext(ctx context.Context, dest interface{}
 		return fmt.Errorf("an error occured whilst preparing the statement: %v", err)
 	}
 
-	query = db.db.Rebind(query)
-	fmt.Printf("query: %v\nargs: %v\n", query, queryArguments)
-	return db.db.SelectContext(ctx, dest, query, queryArguments...)
+	query = db.tx.Rebind(query)
+	return db.tx.SelectContext(ctx, dest, query, queryArguments...)
 }
 
 func (db *sandboxDB) GetContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error {


### PR DESCRIPTION
There was a bug left I missed in the previous PR, and a debug log was inadvertedly merged as well.

The `SelectMultipleContext()` is called from the underlying `db` and not the `tx` struct, which results in not finding any rows inserted as part of the transaction as we do for testing.