### PR TITLE
Remove logging from the /ping route in the monitoring server

### DIFF
--- a/platform/web/server.go
+++ b/platform/web/server.go
@@ -48,11 +48,11 @@ func NewServer(config ServerConfig, router http.Handler) *http.Server {
 
 // NewMonitoringServer creates a new monitoring server configured for metrics and healthz
 func NewMonitoringServer(config ServerConfig, logger *logging.Logger, metricsHandler Handler, serviceCheckers []HealthzChecker) *http.Server {
-	router := NewRouter(logger, DefaultMiddlewares(logger))
+	router := NewRouter(logger, nil)
 
-	router.HandleFunc("GET", "/metrics", metricsHandler)
-	router.HandleFunc("GET", "/ping", pingHandler)
-	router.HandleFunc("GET", "/healthz", HealthzHandler(serviceCheckers))
+	router.HandleFunc("GET", "/metrics", metricsHandler, DefaultMiddlewares(logger)...)
+	router.HandleFunc("GET", "/ping", pingHandler, RecoveryMiddleware(logger), ErrorsMiddleware())
+	router.HandleFunc("GET", "/healthz", HealthzHandler(serviceCheckers), DefaultMiddlewares(logger)...)
 	return NewServer(config, router)
 }
 


### PR DESCRIPTION
 Do not use the logger middleware for the `/ping` route exposed in the monitoring server as we get spammed with non-useful logs when deployed in a k8s cluster