### PR TITLE
Add handling of the error raised by the maxBytesReader in our JSON body decode functions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.16.0
+golang 1.16.5

--- a/platform/database/sandbox.go
+++ b/platform/database/sandbox.go
@@ -91,9 +91,8 @@ func (db *sandboxDB) SelectMultipleContext(ctx context.Context, dest interface{}
 		return fmt.Errorf("an error occured whilst preparing the statement: %v", err)
 	}
 
-	query = db.db.Rebind(query)
-	fmt.Printf("query: %v\nargs: %v\n", query, queryArguments)
-	return db.db.SelectContext(ctx, dest, query, queryArguments...)
+	query = db.tx.Rebind(query)
+	return db.tx.SelectContext(ctx, dest, query, queryArguments...)
 }
 
 func (db *sandboxDB) GetContext(ctx context.Context, dest interface{}, statement string, args ...interface{}) error {

--- a/platform/web/errors.go
+++ b/platform/web/errors.go
@@ -48,6 +48,8 @@ var (
 	InvalidRequestBodyContentMessage = NewErrorMessage("100001", "one ore more of the input parameters was incorrect")
 	// InvalidJSONSchemaFilePath is the error message we return when we were unable to find a json schema at the specified path
 	InvalidJSONSchemaFilePath = NewErrorMessage("100005", "the provided file path for the json schema is invalid")
+	// RequestBodyTooLarge is the error message we return when the request body is larger than the limit set when using http.MaxBytesReader()
+	RequestBodyTooLarge = NewErrorMessage("100006", "the request body is larger than the set size limit")
 )
 
 // NewErrUnmanagedResponse [deprecated] shouldn't be used outside this package. Define application specific errors instead
@@ -110,5 +112,13 @@ func NewErrInvalidJSONSchemaFilePath() error {
 	return &Error{
 		ErrorMessage: InvalidJSONSchemaFilePath,
 		HTTPCode:     http.StatusInternalServerError,
+	}
+}
+
+// NewErrRequestBodyTooLarge is returned when the request body is larger than the limit set by using http.MaxBytesReader()
+func NewErrRequestBodyTooLarge() error {
+	return &Error{
+		HTTPCode:     http.StatusRequestEntityTooLarge,
+		ErrorMessage: RequestBodyTooLarge,
 	}
 }

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -153,6 +153,9 @@ func decode(r *http.Request, val interface{}, options DecoderOptions) error {
 	}
 
 	if err := decoder.Decode(val); err != nil {
+		if err.Error() == "http: request body too large" {
+			return fmt.Errorf("%w", NewErrRequestBodyTooLarge())
+		}
 		switch e := err.(type) {
 		case *json.UnmarshalTypeError:
 			return fmt.Errorf("%v: %w", err, NewErrBadRequestResponse(ErrorDetails{

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -23,6 +23,9 @@ var validate = validator.New()
 var translator *ut.UniversalTranslator
 var fieldRegex = regexp.MustCompile(`json: unknown field "([^"]+)"`)
 
+// ErrRequestBodyTooLargeMessage is the error returned by the http.MaxBytesReader() when reading from a reader over the set limit
+var ErrRequestBodyTooLargeMessage = "http: request body too large"
+
 // DecoderOptions describes a set of options you can pass to alter the behaviour of the decoders
 // AllowUnknownFields ensures that the decoder can pass the json even if it contains a field unknown to the strict
 type DecoderOptions struct {
@@ -80,7 +83,7 @@ func DecodeWithEmbeddedJSONSchema(request *http.Request, model interface{}, json
 func validateRequestPayload(request *http.Request, model interface{}, options DecoderOptions, jsonSchema gojsonschema.JSONLoader) error {
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
-		if err.Error() == "http: request body too large" {
+		if err.Error() == ErrRequestBodyTooLargeMessage {
 			return fmt.Errorf("%w", NewErrRequestBodyTooLarge())
 		}
 		return err
@@ -153,7 +156,7 @@ func decode(r *http.Request, val interface{}, options DecoderOptions) error {
 	}
 
 	if err := decoder.Decode(val); err != nil {
-		if err.Error() == "http: request body too large" {
+		if err.Error() == ErrRequestBodyTooLargeMessage {
 			return fmt.Errorf("%w", NewErrRequestBodyTooLarge())
 		}
 		switch e := err.(type) {

--- a/platform/web/request.go
+++ b/platform/web/request.go
@@ -78,7 +78,13 @@ func DecodeWithEmbeddedJSONSchema(request *http.Request, model interface{}, json
 }
 
 func validateRequestPayload(request *http.Request, model interface{}, options DecoderOptions, jsonSchema gojsonschema.JSONLoader) error {
-	body, _ := io.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		if err.Error() == "http: request body too large" {
+			return fmt.Errorf("%w", NewErrRequestBodyTooLarge())
+		}
+		return err
+	}
 	request.Body = io.NopCloser(bytes.NewBuffer(body))
 	payload := gojsonschema.NewBytesLoader(body)
 


### PR DESCRIPTION
Return a wrapped error we can match on in our `DecodeWithJSONSchema()` and `DecodeWithEmbeddedJSONSchema()` for the error return by the read operation when using `http.MaxBytesReader` for graceful handling up the stack.