### PR TITLE
Add traceID to ersponse header

### DIFF
--- a/platform/web/response.go
+++ b/platform/web/response.go
@@ -13,7 +13,6 @@ import (
 func Respond(ctx context.Context, w http.ResponseWriter, data interface{}, statusCode int) error {
 	v := ctx.Value(KeyValues).(*Values)
 	v.StatusCode = statusCode
-	w.Header().Set("Fewlines-TraceID", v.TraceID)
 
 	if statusCode == http.StatusNoContent {
 		w.WriteHeader(statusCode)

--- a/platform/web/response.go
+++ b/platform/web/response.go
@@ -13,6 +13,7 @@ import (
 func Respond(ctx context.Context, w http.ResponseWriter, data interface{}, statusCode int) error {
 	v := ctx.Value(KeyValues).(*Values)
 	v.StatusCode = statusCode
+	w.Header().Set("Fewlines-TraceID", v.TraceID)
 
 	if statusCode == http.StatusNoContent {
 		w.WriteHeader(statusCode)

--- a/platform/web/router.go
+++ b/platform/web/router.go
@@ -96,6 +96,8 @@ func (a *Router) defineHandler(handler Handler, middlewares ...Middleware) http.
 			Now:     time.Now(),
 		}
 
+		w.Header().Set("Fewlines-TraceID", v.TraceID)
+
 		ctx = context.WithValue(ctx, KeyValues, &v)
 
 		monitoring.AddTagToScope("Trace-ID", v.TraceID)


### PR DESCRIPTION
Add the trace ID to the `Fewlines-TraceID` header when responding to a request.